### PR TITLE
feat: pandoc su ogni commit

### DIFF
--- a/.github/workflows/Pandoc.yml
+++ b/.github/workflows/Pandoc.yml
@@ -1,0 +1,22 @@
+name: Pandoc
+
+on: push
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: create file list
+        id: files_list
+        run: |
+          mkdir output  # create output dir
+          # this will also include README.md
+          echo "::set-output name=files::$(printf '"%s" ' *.md)"
+      - uses: docker://pandoc/latex:2.9
+        with:
+          args: -V geometry:margin=1in --output=output/result.pdf ${{ steps.files_list.outputs.files }}
+      - uses: actions/upload-artifact@master
+        with:
+          name: output
+          path: output

--- a/.github/workflows/Pandoc.yml
+++ b/.github/workflows/Pandoc.yml
@@ -4,15 +4,14 @@ on: push
 
 jobs:
   convert_via_pandoc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: create file list
         id: files_list
         run: |
           mkdir output  # create output dir
-          # this will also include README.md
-          echo "::set-output name=files::$(printf '"%s" ' *.md)"
+          echo "::set-output name=files::$(cat .github/workflows/files.txt)"
       - uses: docker://pandoc/latex:2.9
         with:
           args: -V geometry:margin=1in --output=output/result.pdf ${{ steps.files_list.outputs.files }}

--- a/.github/workflows/files.txt
+++ b/.github/workflows/files.txt
@@ -1,1 +1,1 @@
-"README.md", "esami.md", "Guide/README.md", "Guide/consigli_tecnici_esami_online.md", "Guide/Office/README.md", "Guide/dove_mangiare.md", "FAQ/README.md"
+"README.md" "esami.md" "Guide/README.md" "Guide/consigli_tecnici_esami_online.md" "Guide/Office/README.md" "Guide/dove_mangiare.md" "FAQ/README.md"

--- a/.github/workflows/files.txt
+++ b/.github/workflows/files.txt
@@ -1,0 +1,1 @@
+"README.md", "esami.md", "Guide/README.md", "Guide/consigli_tecnici_esami_online.md", "Guide/Office/README.md", "Guide/dove_mangiare.md", "FAQ/README.md"


### PR DESCRIPTION
Ad ogni commit genera un PDF con i file elencati dentro .github/workflows/files.txt

Li ho inseriti a mano per evitare problemi, tecnicamente si potrebbe fare uno script per escludere certe cartelle e buttare tutti i file in markdown, ma questo funziona molto bene.
Date un occhio al mio [fork](https://github.com/TheTipo01/guida_degli_studenti_di) per vedere come funziona (il pallino affianco ai commit)